### PR TITLE
[GTK] Initialize text-antialias when initializing Image GC object

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT PI/cairo/library/cairo.c
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/cairo/library/cairo.c
@@ -15,7 +15,7 @@
  *
  * IBM
  * -  Binding to permit interfacing between Cairo and SWT
- * -  Copyright (C) 2005, 2022 IBM Corp.  All Rights Reserved.
+ * -  Copyright (C) 2005, 2025 IBM Corp.  All Rights Reserved.
  *
  * ***** END LICENSE BLOCK ***** */
 
@@ -1058,6 +1058,16 @@ JNIEXPORT void JNICALL Cairo_NATIVE(cairo_1set_1fill_1rule)
 	Cairo_NATIVE_ENTER(env, that, cairo_1set_1fill_1rule_FUNC);
 	cairo_set_fill_rule((cairo_t *)arg0, arg1);
 	Cairo_NATIVE_EXIT(env, that, cairo_1set_1fill_1rule_FUNC);
+}
+#endif
+
+#ifndef NO_cairo_1set_1font_1options
+JNIEXPORT void JNICALL Cairo_NATIVE(cairo_1set_1font_1options)
+	(JNIEnv *env, jclass that, jlong arg0, jlong arg1)
+{
+	Cairo_NATIVE_ENTER(env, that, cairo_1set_1font_1options_FUNC);
+	cairo_set_font_options((cairo_t *)arg0, (const cairo_font_options_t *)arg1);
+	Cairo_NATIVE_EXIT(env, that, cairo_1set_1font_1options_FUNC);
 }
 #endif
 

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/cairo/library/cairo.c
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/cairo/library/cairo.c
@@ -260,6 +260,16 @@ JNIEXPORT jlong JNICALL Cairo_NATIVE(cairo_1get_1font_1face)
 }
 #endif
 
+#ifndef NO_cairo_1get_1font_1options
+JNIEXPORT void JNICALL Cairo_NATIVE(cairo_1get_1font_1options)
+	(JNIEnv *env, jclass that, jlong arg0, jlong arg1)
+{
+	Cairo_NATIVE_ENTER(env, that, cairo_1get_1font_1options_FUNC);
+	cairo_get_font_options((cairo_t *)arg0, (cairo_font_options_t *)arg1);
+	Cairo_NATIVE_EXIT(env, that, cairo_1get_1font_1options_FUNC);
+}
+#endif
+
 #ifndef NO_cairo_1get_1matrix
 JNIEXPORT void JNICALL Cairo_NATIVE(cairo_1get_1matrix)
 	(JNIEnv *env, jclass that, jlong arg0, jdoubleArray arg1)

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/cairo/library/cairo_stats.h
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/cairo/library/cairo_stats.h
@@ -50,6 +50,7 @@ typedef enum {
 	cairo_1get_1current_1point_FUNC,
 	cairo_1get_1fill_1rule_FUNC,
 	cairo_1get_1font_1face_FUNC,
+	cairo_1get_1font_1options_FUNC,
 	cairo_1get_1matrix_FUNC,
 	cairo_1get_1source_FUNC,
 	cairo_1get_1target_FUNC,

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/cairo/library/cairo_stats.h
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/cairo/library/cairo_stats.h
@@ -15,7 +15,7 @@
  *
  * IBM
  * -  Binding to permit interfacing between Cairo and SWT
- * -  Copyright (C) 2005, 2023 IBM Corp.  All Rights Reserved.
+ * -  Copyright (C) 2005, 2025 IBM Corp.  All Rights Reserved.
  *
  * ***** END LICENSE BLOCK ***** */
 
@@ -116,6 +116,7 @@ typedef enum {
 	cairo_1set_1antialias_FUNC,
 	cairo_1set_1dash_FUNC,
 	cairo_1set_1fill_1rule_FUNC,
+	cairo_1set_1font_1options_FUNC,
 	cairo_1set_1font_1size_FUNC,
 	cairo_1set_1line_1cap_FUNC,
 	cairo_1set_1line_1join_FUNC,

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/cairo/org/eclipse/swt/internal/cairo/Cairo.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/cairo/org/eclipse/swt/internal/cairo/Cairo.java
@@ -291,6 +291,11 @@ public static final native void cairo_set_source_rgba(long cr, double red, doubl
 public static final native void cairo_set_source_surface(long cr, long surface, double x, double y);
 /** @param cr cast=(cairo_t *) */
 public static final native void cairo_set_tolerance(long cr, double tolerance);
+/**
+ * @param cr cast=(cairo_t *)
+ * @param options cast=(const cairo_font_options_t *)
+ */
+public static final native void cairo_set_font_options(long cr, long options);
 /** @param cr cast=(cairo_t *) */
 public static final native void cairo_show_page(long cr);
 /** @param cr cast=(cairo_t *) */

--- a/bundles/org.eclipse.swt/Eclipse SWT PI/cairo/org/eclipse/swt/internal/cairo/Cairo.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT PI/cairo/org/eclipse/swt/internal/cairo/Cairo.java
@@ -296,6 +296,11 @@ public static final native void cairo_set_tolerance(long cr, double tolerance);
  * @param options cast=(const cairo_font_options_t *)
  */
 public static final native void cairo_set_font_options(long cr, long options);
+/**
+ * @param cr cast=(cairo_t *)
+ * @param options cast=(cairo_font_options_t *)
+ */
+public static final native void cairo_get_font_options(long cr, long options);
 /** @param cr cast=(cairo_t *) */
 public static final native void cairo_show_page(long cr);
 /** @param cr cast=(cairo_t *) */

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/GC.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/GC.java
@@ -3763,6 +3763,7 @@ public void setTextAntialias(int antialias) {
 	}
 	initCairo();
 	long options = Cairo.cairo_font_options_create();
+	Cairo.cairo_get_font_options(data.cairo, options);
 	Cairo.cairo_font_options_set_antialias(options, mode);
 	if (data.context == 0) createLayout();
 	OS.pango_cairo_context_set_font_options(data.context, options);

--- a/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/Image.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT/gtk/org/eclipse/swt/graphics/Image.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -1446,6 +1446,12 @@ public long internal_new_GC (GCData data) {
 		SWT.error(SWT.ERROR_INVALID_ARGUMENT);
 	}
 	long gc = Cairo.cairo_create(surface);
+	if (gc != 0) {
+		long options = Cairo.cairo_font_options_create();
+		Cairo.cairo_font_options_set_antialias(options, Cairo.CAIRO_ANTIALIAS_DEFAULT);
+		Cairo.cairo_set_font_options(gc, options);
+		Cairo.cairo_font_options_destroy(options);
+	}
 	if (data != null) {
 		int mask = SWT.LEFT_TO_RIGHT | SWT.RIGHT_TO_LEFT;
 		if ((data.style & mask) == 0) {

--- a/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_Image.java
+++ b/tests/org.eclipse.swt.tests/JUnit Tests/org/eclipse/swt/tests/junit/Test_org_eclipse_swt_graphics_Image.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -1257,4 +1257,46 @@ public void test_updateWidthHeightAfterDPIChange() {
 		DPIUtil.setDeviceZoom(deviceZoom);
 	}
 }
+
+@Test
+public void test_paintWithTextAntialias() {
+	// Must be executed on e.g. a Gnome system
+	// where anti-alias is set to use Grayscale
+	// whereas Cairo is using RGB by default
+	int[] modes = {SWT.ON, SWT.OFF, SWT.DEFAULT};
+	int width = (modes.length + 1) * 100;
+	int height = 100;
+
+	Image image1 = new Image(display, width, height);
+	GC g1 = new GC(image1);
+	g1.setAdvanced(true);
+
+	g1.drawString("OWVO", 35, 20);
+	for (int i = 0 ; i < modes.length; ++i) {
+		g1.setTextAntialias(modes[i]);
+		g1.drawString("OWVO", 135 + i * 100, 20);
+	}
+
+	Image image2 = new Image(display, width, height);
+	GC g2 = new GC(image2);
+	g2.setAdvanced(true);
+
+	for (int i = modes.length - 1 ; i >= 0; --i) {
+		g2.setTextAntialias(modes[i]);
+		g2.drawString("OWVO", 135 + i * 100, 20);
+	}
+	g2.setTextAntialias(SWT.DEFAULT);
+	g2.drawString("OWVO", 35, 20);
+
+	ImageData data1 = image1.getImageData();
+	ImageData data2 = image2.getImageData();
+
+	g1.dispose();
+	g2.dispose();
+	image1.dispose();
+	image2.dispose();
+
+	ImageTestUtil.assertImagesEqual(data1, data2);
+}
+
 }


### PR DESCRIPTION
If a string is drawn without ever calling setTextAntialias(), the Cairo default is used. If this method is called with SWT.DEFAULT, the system default is used. Because those values are not guaranteed to be equal, this may then lead to different results.

To avoid this ambiguity, the GC needs to be explicitly initialized with the system default value.